### PR TITLE
fix (ngx-input-datepicker): handle months with six rows of days

### DIFF
--- a/projects/ngx-input-datepicker/src/ngx-input-datepicker.component.scss
+++ b/projects/ngx-input-datepicker/src/ngx-input-datepicker.component.scss
@@ -124,7 +124,8 @@ ngx-input-datepicker {
 
     .ngx-input-datepicker {
       position: absolute;
-      bottom: -233px;
+      bottom: -263px;
+      height: 264px;
       z-index: 2;
     }
   }


### PR DESCRIPTION
This commit fixes a bug in the date picker component where certain months were styled awkwardly due to having an extra row of days.