### PR TITLE
refactor(ngx-json-ld): improve performance by removing ngOnChange

### DIFF
--- a/projects/ngx-json-ld/src/ngx-json-ld.component.spec.ts
+++ b/projects/ngx-json-ld/src/ngx-json-ld.component.spec.ts
@@ -44,7 +44,7 @@ describe('NgxJsonLdComponent', () => {
 
   it('should update schema in template', () => {
     const initialName = testSchema.name;
-    const predictedName = 'Unlimited Ball Bearings Corp.';
+    const predictedName = 'Limited Ball Bearings Corp.';
 
     component.json = testSchema;
     fixture.detectChanges();
@@ -52,6 +52,7 @@ describe('NgxJsonLdComponent', () => {
 
     testSchema.name = predictedName;
     component.json = testSchema;
+    fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML).toContain(predictedName);
   });
 

--- a/projects/ngx-json-ld/src/ngx-json-ld.component.spec.ts
+++ b/projects/ngx-json-ld/src/ngx-json-ld.component.spec.ts
@@ -38,18 +38,25 @@ describe('NgxJsonLdComponent', () => {
 
   it('should create schema in the template', () => {
     component.json = testSchema;
-    component.ngOnChanges({
-      json: new SimpleChange(null, component.json, false)
-    });
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML).toContain('http://schema.org');
   });
 
+  it('should update schema in template', () => {
+    const initialName = testSchema.name;
+    const predictedName = 'Unlimited Ball Bearings Corp.';
+
+    component.json = testSchema;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerHTML).toContain(initialName);
+
+    testSchema.name = predictedName;
+    component.json = testSchema;
+    expect(fixture.nativeElement.innerHTML).toContain(predictedName);
+  });
+
   it('should prevent script injection', () => {
     component.json = testSchema;
-    component.ngOnChanges({
-      json: new SimpleChange(null, component.json, false)
-    });
     fixture.detectChanges();
     expect((window as any).scriptInjection).toBe(undefined);
   });

--- a/projects/ngx-json-ld/src/ngx-json-ld.component.ts
+++ b/projects/ngx-json-ld/src/ngx-json-ld.component.ts
@@ -2,8 +2,6 @@ import {
   Component,
   HostBinding,
   Input,
-  OnChanges,
-  SimpleChanges,
   ChangeDetectionStrategy
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
@@ -13,14 +11,13 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
   template: '',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class NgxJsonLdComponent implements OnChanges {
-  @Input() json;
+export class NgxJsonLdComponent {
+  @Input()
+  set json(currentValue: {}) {
+    this.jsonLD = this.getSafeHTML(currentValue);
+  }
   @HostBinding('innerHTML') jsonLD: SafeHtml;
   constructor(private sanitizer: DomSanitizer) {}
-
-  ngOnChanges(changes: SimpleChanges) {
-    this.jsonLD = this.getSafeHTML(changes.json.currentValue);
-  }
 
   getSafeHTML(value: {}) {
     const json = value


### PR DESCRIPTION
Removed ngOnChange life cycle since it is not needed, instead we can use a simple setter.