### PR TITLE
 feat(ngx-input-tag): add 'maxTagLength' input and export tag formatter injection token

### DIFF
--- a/projects/ngx-input-tag/src/ngx-input-tag.component.ts
+++ b/projects/ngx-input-tag/src/ngx-input-tag.component.ts
@@ -33,8 +33,6 @@ export enum KeyCodes {
   Comma = 188
 }
 
-const maxTagLength = 25;
-
 @Component({
   selector: 'ngx-input-tag',
   templateUrl: './ngx-input-tag.component.html',
@@ -67,6 +65,7 @@ export class NgxInputTagComponent implements ControlValueAccessor {
 
   @ViewChild('inputElement') inputElement: ElementRef;
   @Input() tagSuggestions: string[] = [];
+  @Input() maxTagLength = 25;
   @Input() maxNumberOfTags = 1000;
   @Output() readonly textChange = new EventEmitter<string>();
 
@@ -116,14 +115,14 @@ export class NgxInputTagComponent implements ControlValueAccessor {
     const formattedTag = this.tagFormatter(tag);
     const tagIsEmpty = formattedTag.length === 0;
     const invalidTagLength =
-      !formattedTag.length || formattedTag.length > maxTagLength;
+      !formattedTag.length || (this.maxTagLength && formattedTag.length > this.maxTagLength);
     const duplicateTag = this.value.indexOf(formattedTag) > -1;
     const exceedsMaxNumberOfTags =
       this.currentNumberOfTags > this.maxNumberOfTags;
 
     if (!tagIsEmpty && invalidTagLength) {
       this.tagError = {
-        message: `Tag length cannot exceed ${maxTagLength} characters`
+        message: `Tag length cannot exceed ${this.maxTagLength} characters`
       };
     }
 

--- a/projects/ngx-input-tag/src/public_api.ts
+++ b/projects/ngx-input-tag/src/public_api.ts
@@ -3,4 +3,5 @@
  */
 
 export * from './ngx-input-tag.component';
+export * from './ngx-input-tag.di-tokens';
 export * from './ngx-input-tag.module';


### PR DESCRIPTION
**What's different?**
- `maxTagLength` is no longer hard coded.
- `NGX_INPUT_TAG_TAG_FORMATTER` is exported.