### PR TITLE
Added minify property on NgxJsonLdComponent

### DIFF
--- a/projects/ngx-json-ld/src/ngx-json-ld.component.ts
+++ b/projects/ngx-json-ld/src/ngx-json-ld.component.ts
@@ -12,17 +12,46 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NgxJsonLdComponent {
-  @Input()
-  set json(currentValue: {}) {
-    this.jsonLD = this.getSafeHTML(currentValue);
+
+  //#region Json
+  private _json: any = {};
+  get json() {
+    return this._json;
   }
+  @Input() set json(value: {}) {
+    this._json = value;
+    this.updateJsonLd();
+  }
+  //#endregion
+  //#region Minify
+  private _minify: boolean = false;
+  get minify() {
+    return this._minify;
+  }
+  @Input() set minify(value: boolean) {
+    this._minify = value;
+    this.updateJsonLd();
+  }
+  //#endregion
+
   @HostBinding('innerHTML') jsonLD: SafeHtml;
   constructor(private sanitizer: DomSanitizer) {}
 
-  getSafeHTML(value: {}) {
-    const json = value
-      ? JSON.stringify(value, null, 2).replace(/<\/script>/g, '<\\/script>')
-      : '';
+  private updateJsonLd() {
+    this.jsonLD = this.getSafeHTML(this._json, this._minify);
+  }
+
+  private getSafeHTML(value: {}, minify: boolean) {
+    let json = null;
+    if (minify === true) {
+      json = value
+        ? JSON.stringify(value).replace(/<\/script>/g, '<\\/script>')
+        : '';
+    } else {
+      json = value
+        ? JSON.stringify(value, null, 2).replace(/<\/script>/g, '<\\/script>')
+        : '';
+    }
     const html = `<script type="application/ld+json">${json}</script>`;
     return this.sanitizer.bypassSecurityTrustHtml(html);
   }


### PR DESCRIPTION
Now the generated JSON is always like this:

	<script type="application/ld+json">{
	  "@context": "http://schema.org",
	  "@type": "MusicRecording",
	  "url": "https://mintplayer.com/song/16",
	  "name": "Spaceman",
	  "image": "http://i.ytimg.com/vi/XCbAEkfXSDE/hqdefault.jpg",
	  "datePublished": "1996-01-14T23:00:00.000Z",
	  "byArtist": [
		{
		  "@context": "http://schema.org",
		  "@type": "MusicGroup",
		  "name": "BABYLON ZOO",
		  "url": "https://mintplayer.com/artist/15"
		}
	  ]
	}</script>

This pull request would allow you to choose if you want to keep the minified Json, by setting a [minify]="true" binding.