### PR TITLE
feat (ngx-input-datepicker): update "date-fns" and use ES imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2693,9 +2693,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz",
+      "integrity": "sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw=="
     },
     "date-format": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@angular/platform-browser-dynamic": "~8.0.0",
     "@angular/router": "~8.0.0",
     "blueprint-css": "^3.1.1",
-    "date-fns": "^1.29.0",
+    "date-fns": "^2.14.0",
     "normalize.css": "^8.0.0",
     "prismjs": "^1.14.0",
     "resize-observer-polyfill": "^1.5.0",

--- a/projects/ngx-input-datepicker/package.json
+++ b/projects/ngx-input-datepicker/package.json
@@ -9,6 +9,6 @@
     "@angular/core": "^8.0.0",
     "@angular/common": "^8.0.0",
     "@angular/forms": "^8.0.0",
-    "date-fns": "^1.29.0"
+    "date-fns": "^2.14.0"
   }
 }

--- a/projects/ngx-input-datepicker/src/ngx-input-datepicker.component.ts
+++ b/projects/ngx-input-datepicker/src/ngx-input-datepicker.component.ts
@@ -9,13 +9,13 @@ import {
   ChangeDetectionStrategy
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import * as addMonths_ from 'date-fns/add_months';
-import * as subMonths_ from 'date-fns/sub_months';
-import * as setDate_ from 'date-fns/set_date';
-import * as isToday_ from 'date-fns/is_today';
-import * as getDayOfYear_ from 'date-fns/get_day_of_year';
-import * as isBefore_ from 'date-fns/is_before';
-import * as isAfter_ from 'date-fns/is_after';
+import addMonths from 'date-fns/esm/addMonths';
+import subMonths from 'date-fns/esm/subMonths';
+import setDate from 'date-fns/esm/setDate';
+import isToday from 'date-fns/esm/isToday';
+import getDayOfYear from 'date-fns/esm/getDayOfYear';
+import isBefore from 'date-fns/esm/isBefore';
+import isAfter from 'date-fns/esm/isAfter';
 
 import {
   removeTimeIfAvailable,
@@ -28,15 +28,6 @@ import {
   weekDays,
   monthNames
 } from './util';
-
-// https://github.com/rollup/rollup/issues/670
-const addMonths = addMonths_;
-const subMonths = subMonths_;
-const setDate = setDate_;
-const isToday = isToday_;
-const getDayOfYear = getDayOfYear_;
-const isBefore = isBefore_;
-const isAfter = isAfter_;
 
 let instanceId = 0;
 

--- a/projects/ngx-input-datepicker/src/util.ts
+++ b/projects/ngx-input-datepicker/src/util.ts
@@ -1,14 +1,8 @@
-import * as isSameDay_ from 'date-fns/is_same_day';
-import * as isSameYear_ from 'date-fns/is_same_year';
-import * as getDaysInMonth_ from 'date-fns/get_days_in_month';
-import * as isBefore_ from 'date-fns/is_before';
-import * as isAfter_ from 'date-fns/is_after';
-
-const getDaysInMonth = getDaysInMonth_;
-const isSameYear = isSameYear_;
-const isSameDay = isSameDay_;
-const isBefore = isBefore_;
-const isAfter = isAfter_;
+import isSameDay from 'date-fns/esm/isSameDay';
+import isSameYear from 'date-fns/esm/isSameYear';
+import getDaysInMonth from 'date-fns/esm/getDaysInMonth';
+import isBefore from 'date-fns/esm/isBefore';
+import isAfter from 'date-fns/esm/isAfter';
 
 export const weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 


### PR DESCRIPTION
Angular 10 has new compiler warning about commonjs module imports. Updating to `date-fn@2.x` and using the ES import should help users of the date picker package who what to update to Angular 10.

Also, the peer dependency on `date-fns@^1.29.0` prevents package consumers from updating their own application to `date-fns@2.x` regardless of any updates to Angular 10.