### PR TITLE
Fix repo link

### DIFF
--- a/projects/ngx-json-ld/package.json
+++ b/projects/ngx-json-ld/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ngx-lite/json-ld",
   "version": "14.0.0",
-  "repository": "https://github.com/coryrylan/ngx-json-ld",
+  "repository": "https://github.com/coryrylan/ngx-lite",
   "author": "Cory Rylan",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
During [the update](https://github.com/coryrylan/ngx-lite/pull/87) I found out that `json-ld` package link leads to the old archived repo